### PR TITLE
fix: tp3 nginx conf

### DIFF
--- a/tp/03_loadbalancing.md
+++ b/tp/03_loadbalancing.md
@@ -111,9 +111,10 @@ Ajoutez ceci :
 
           server {
               listen 80;
+              server_name http://iaas-<N>-1.beercraft.cloud;
 
               location / {
-                  proxy_pass http://iaas-<N>-1.beercraft.cloud;
+                  proxy_pass http://beercraft;
                   proxy_set_header Host $host;
                   proxy_set_header X-Real-IP $remote_addr;
                   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
### Problème

La configuration nginx pour le loadbalancer n'était pas reliée aux différents backends.  
